### PR TITLE
Fix error for response type returning None

### DIFF
--- a/backend/src/api/api_handler.py
+++ b/backend/src/api/api_handler.py
@@ -50,6 +50,9 @@ def submit_query_endpoint(request: SubmitQueryRequest) -> DBQueryModel:
 
     # Make a synchronous call to the worker (the RAG/AI app).
     query_response = query_rag(request.query_text)
+    if query_response is None:
+        return "Error: No response recieved for query_rag."
+    print(f"Query response: {query_response}")
     new_query.answer_text = query_response.response_text
     new_query.sources = query_response.sources
     new_query.is_complete = True

--- a/backend/src/app_logic/query_data.py
+++ b/backend/src/app_logic/query_data.py
@@ -40,7 +40,9 @@ def query_rag(query_text: str) -> QueryResponse:
     #check if results are suitable
     if len(results) == 0 or results[0][1] < 0.7:
         print(f"Unable to find matching results.")
-        return
+        #When no results are found we return, however we are not returning a QueryResponse object.
+        #To fix this we are going to are going to return a QueryResponse object with the statement "No suitable results found"
+        return QueryResponse(query_text=query_text, response_text="No suitable results found.", sources=[])
     
     context_text = "\n\n---\n\n".join([doc.page_content for doc, _score in results])
     prompt_template = ChatPromptTemplate.from_template(PROMPT_TEMPLATE)


### PR DESCRIPTION
Running a similarity check comparing the query to our documents loaded in Chroma db sometimes resulted in a None type error. This happened when a query did not match anything in Chroma. When checking if the response is suitable, we would simply return. 

Now, we return a QueryResponse object that has response_text="No suitable response found."
For further protection, after getting the QueryResponse object from the response, we do a final check to confirm that it is not None.